### PR TITLE
Add sample config for upstart 1.5

### DIFF
--- a/recipes/using-upstart/logstash-agent.conf
+++ b/recipes/using-upstart/logstash-agent.conf
@@ -11,10 +11,11 @@ respawn
 respawn limit 5 30
 expect fork
 
+# You need to chdir somewhere writable because logstash needs to unpack a few
+# temporary files on startup.
+chdir /home/logstash
+
 script
-  # You need to chdir somewhere writable because logstash needs to unpack a few
-  # temporary files on startup.
-  chdir /home/logstash
 
   # This runs logstash agent as the 'logstash' user
   su -s /bin/sh -c 'exec "$0" "$@"' logstash -- /usr/bin/java -jar logstash.jar agent -f /etc/logstash/agent.conf --log /var/log/logstash.log &

--- a/recipes/using-upstart/logstash-indexer.conf
+++ b/recipes/using-upstart/logstash-indexer.conf
@@ -1,0 +1,21 @@
+# logstash - indexer instance
+#
+
+description     "logstash indexer instance"
+
+start on virtual-filesystems
+stop on runlevel [06]
+
+respawn
+respawn limit 5 30
+
+#env JAVA_OPTS='-Xms512m -Xmx512m'
+chdir /opt/logstash
+setuid logstash
+setgid adm
+console log
+
+script
+        exec java -jar logstash.jar agent -f /etc//indexer.conf --log /var/log/logstash-indexer.out -- web --log /var/log/logstash-web.out --backend elasticsearch://localhost/
+end script
+


### PR DESCRIPTION
Add a sample upstart config for an indexer/elasticsearch instance.
Additionally fix minor syntax/semantics issues with the old example.
That old example is still required for Ubuntu 10.04 LTS through 11.10.
