### PR TITLE
Update recipes/apache-json-logs/apache.conf

### DIFF
--- a/recipes/apache-json-logs/apache.conf
+++ b/recipes/apache-json-logs/apache.conf
@@ -1,9 +1,8 @@
-
 # Create a log format called 'logstash_json' that emits, in json, the parts of an http
 # request I care about. For more details on the features of the 'LogFormat'
 # directive, see the apache docs:
 # http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats
-LogFormat "{ \"@timestamp\": \"%{%Y/%m/%dT%H:%M:%S%z}t\", \"@fields\": { \"client\": \"%a\", \"duration_usec\": %D, \"status\": %s, \"request\": \"%U%q\", \"method\": \"%m\", \"referrer\": \"%{Referer}i\" } }" logstash_json
+LogFormat "{ \"@timestamp\": \"%{%Y-%m-%dT%H:%M:%S%z}t\", \"@fields\": { \"client\": \"%a\", \"duration_usec\": %D, \"status\": %s, \"request\": \"%U%q\", \"method\": \"%m\", \"referrer\": \"%{Referer}i\" } }" logstash_json
 
 
 # Write our 'logstash_json' logs to logs/access_json.log


### PR DESCRIPTION
this change should solve this error while pushing content to elasticsearch:
"exception":"java.lang.IllegalArgumentException: Invalid format: \"2012/08/23T18:07:40+0200\" is malformed at \"/08/23T18:07:40+0200\"","backtrace":["org/joda/time/format/DateTimeFormatter.java:866:in `parseDateTime'","file:/root/logstash-1.1.1-monolithic.jar!/logstash/event.rb:220
