### PR TITLE
update upstart example to set HOME environment var

### DIFF
--- a/recipes/using-upstart/logstash-indexer.conf
+++ b/recipes/using-upstart/logstash-indexer.conf
@@ -9,13 +9,23 @@ stop on runlevel [06]
 respawn
 respawn limit 5 30
 
+# set HOME to point to where you want the embedded elasticsearch
+# data directory to be created and ensure /opt/logstash is owned
+# by logstash:adm
+
+#env HOME=/opt/logstash
+
 #env JAVA_OPTS='-Xms512m -Xmx512m'
+
 chdir /opt/logstash
 setuid logstash
 setgid adm
 console log
 
+# for versions 1.1.1 - 1.1.4 the internal web service crashes when touched
+# and the current workaround is to just not run it and run Kibana instead
+
 script
-        exec java -jar logstash.jar agent -f /etc/indexer.conf --log /var/log/logstash-indexer.out -- web --log /var/log/logstash-web.out --backend elasticsearch://localhost/
+        exec java -jar logstash.jar agent -f /etc/indexer.conf --log /var/log/logstash-indexer.out 
 end script
 


### PR DESCRIPTION
added note about setting of HOME env variable and a short
message about why the internal web service is removed
