### PR TITLE
updated syslog.conf example with date/match

### DIFF
--- a/recipes/syslog-pri/syslog.conf
+++ b/recipes/syslog-pri/syslog.conf
@@ -21,7 +21,7 @@ filter {
   }
   date {
       type => "syslog"
-      syslog_timestamp => [ "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
+      match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
   }
   mutate {
       type => "syslog"


### PR DESCRIPTION
the date filter should use match => ["field", "pattern"] now according
to the docs, so update the example
