### PR TITLE
Parse anacron on osfamily redhat too.

### DIFF
--- a/recipes/syslog-pri/syslog.conf
+++ b/recipes/syslog-pri/syslog.conf
@@ -12,7 +12,7 @@ input {
 filter {
   grok {
       type => "syslog"
-      pattern => [ "<%{POSINT:syslog_pri}>%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:syslog_hostname} %{PROG:syslog_program}(?:\[%{POSINT:syslog_pid}\])?: %{GREEDYDATA:syslog_message}" ]
+      pattern => [ "<%{POSINT:syslog_pri}>%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?: %{GREEDYDATA:syslog_message}" ]
       add_field => [ "received_at", "%{@timestamp}" ]
       add_field => [ "received_from", "%{@source_host}" ]
   }


### PR DESCRIPTION
On the osfamily RedHat the anacron messages result in _grokparsefailures, e.g.:

Mar 13 15:01:01 hostname run-parts(/etc/cron.hourly)[3036]: starting mcelog.cron

By changing PROG to DATA in the grok pattern the issue seem to be solved, without breaking anything else. 

Perhaps it's worth changing it permanently in the syslog_pri cookbook recipe?
