### PR TITLE
change init script set_pidfile() to get pid in a more generic way

### DIFF
--- a/recipes/using-init/logstash.sh
+++ b/recipes/using-init/logstash.sh
@@ -62,7 +62,7 @@ do_start()
 
 set_pidfile()
 {
-  ps auxww | grep 'logstash.*monolithic' | grep java | awk '{print $2}' > $PIDFILE
+  pgrep -f "$DAEMON[[:space:]]*$ARGS" > $PIDFILE
 }
 
 #


### PR DESCRIPTION
the function set_pidfile() in the init script have the process name is hardcoded and uses many pipe,
I've change it to use the pgrep and to use (the already defined) $DAEMON and $ARGS arguments to grep the pid.
