### PR TITLE
Remove extra spaces that cause Apache syntax errors, formatting issues

### DIFF
--- a/recipes/apache-json-logs/macro.conf
+++ b/recipes/apache-json-logs/macro.conf
@@ -1,4 +1,3 @@
-
 # Create a Macro named logstash_log that is used in the VirtualHost
 # It defines, on the fly, a macro for the specific vhost $servername
 # and anchors its @source, $source_host and @source_path.
@@ -10,16 +9,16 @@
 		   \"@tags\":[\"${servername}\"], \
 		   \"@message\": \"%h %l %u %t \\\"%r\\\" %>s %b\", \ 
 		   \"@fields\": { \
-			   \"timestamp\": \ "%{%Y-%m-%dT%H:%M:%S%z}t\", \
-			   \"clientip\": \" %a\", \
-			   \"duration\": %D , \
+			   \"timestamp\": \"%{%Y-%m-%dT%H:%M:%S%z}t\", \
+			   \"clientip\": \"%a\", \
+			   \"duration\": %D, \
 			   \"status\": %>s, \
-			   \"request\": \"% U%q\", \
-			   \"urlpath\": \"% U\", \
-			   \"urlquery\": \" %q\", \
-			   \"method\": \"%m \", \
+			   \"request\": \"%U%q\", \
+			   \"urlpath\": \"%U\", \
+			   \"urlquery\": \"%q\", \
+			   \"method\": \"%m\", \
 			   \"bytes\": %B, \ 
-			   \"vhost\": \"%v\ " \
+			   \"vhost\": \"%v\" \
 		   } \
 	   }" logstash_apache_json
 


### PR DESCRIPTION
This patch fixes issues where extra spaces were added, causing Apache syntax errors and minor formatting issues. The syntax errors include things like `% U` instead of `%U` for urlpath. The formatting issues include log output where the request method logs as "GET " instead of "GET".

Not included in this patch, however, is the fact that with Apache 2.2 and mod_macro 1.1.x, the extra padding to the left of the LogFormat lines gets included in the actual log output. So all of the lines between `LogFormat` and `CustomLog` should be fully left-justified to avoid extra tabs or spaces appearing in the log. The whitespace is harmless as far as valid JSON is concerned, but they do increase log size. If desired, I can submit that change as well.
