### PR TITLE
Update logstash.conf example to comply with deprecation in logstash 1.2.x

### DIFF
--- a/recipes/apache-json-logs/logstash.conf
+++ b/recipes/apache-json-logs/logstash.conf
@@ -3,8 +3,10 @@ input {
     path => "/var/log/httpd/access_json.log" 
     type => apache 
 
-    # This format tells logstash to expect 'logstash' json events from the file.
-    format => json_event 
+    # This codec tells logstash to expect json events seperated by newlines from the file.
+    codec => json_lines {
+      charset => "UTF-8"
+    }
   }
 }
 


### PR DESCRIPTION
Changed format => "json_event" to codec => json_lines...
