### PR TITLE
Fix syslog recipe for host / message schema change

### DIFF
--- a/recipes/syslog-pri/syslog.conf
+++ b/recipes/syslog-pri/syslog.conf
@@ -22,8 +22,8 @@ filter {
     }
     if !("_grokparsefailure" in [tags]) {
       mutate {
-        replace => [ "@source_host", "%{syslog_hostname}" ]
-        replace => [ "@message", "%{syslog_message}" ]
+        replace => [ "host", "%{syslog_hostname}" ]
+        replace => [ "message", "%{syslog_message}" ]
       }
     }
     mutate {


### PR DESCRIPTION
This recipe still had some references to the old schema changed in https://logstash.jira.com/browse/LOGSTASH-675.

(But was otherwise quite useful! :+1:)
