### PR TITLE
Don't use port 5544 which is known to be used by a trojan/worm

### DIFF
--- a/recipes/rsyslog-agent/index.md
+++ b/recipes/rsyslog-agent/index.md
@@ -47,4 +47,4 @@ Here is an example config that takes syslog and emits it to stdout:
 
 {% include_code logstash.conf %}
 
-The above sets up logstash to listen on port 5544 for syslog messages.
+The above sets up logstash to listen on port 10514 for syslog messages.

--- a/recipes/rsyslog-agent/logstash.conf
+++ b/recipes/rsyslog-agent/logstash.conf
@@ -1,7 +1,7 @@
 input {
   syslog {
     type => syslog
-    port => 5544
+    port => 10514
   }
 }
 

--- a/recipes/rsyslog-agent/rsyslog.conf
+++ b/recipes/rsyslog-agent/rsyslog.conf
@@ -20,5 +20,5 @@ $InputFileTag mysql:
 $InputFileStateFile state-mysql
 $InputRunFileMonitor
 
-# Send everything to a logstash server named 'myserver' on port 5544:
-*.* @@myserver:5544
+# Send everything to a logstash server named 'myserver' on port 10514:
+*.* @@myserver:10514


### PR DESCRIPTION
see http://www.speedguide.net/port.php?port=5544
port 5544 is known to be used by certain worm/trojan.
It's better if the user did not open up a hole in their firewall.

plus 10514 is more common for user defined rsyslog port.
