### PR TITLE
Add deprecation warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Deprecated
+
+This repository is deprecated and only made available for historical
+interest.  The information available in the cookbook was out of date
+and often quite incorrect, so to avoid confusing new users, the site
+has been shutdown.
+
+Original README below:
+
 # logstash cookbook!
 
 A logstash community-driven site for documentation, shared experiences, etc.


### PR DESCRIPTION
Make it clear to users that the cookbook is no longer publicly visible.

Probably worth changing the repository description as well?

Closes #95.
